### PR TITLE
Issue 5: proxy guards

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -1,3 +1,4 @@
+/* istanbul ignore file */
 const sharedPresets = [];
 const shared = {
   presets: sharedPresets,

--- a/src/datum_plan.js
+++ b/src/datum_plan.js
@@ -503,6 +503,12 @@ export function makeExports({fuse, isLens, lens}) {
    * The resulting datum plan will be structured vaguely like *spec* and
    * constructed to access a value of similar shape to *spec*.
    *
+   * If *options.planGroup* is given, the constructed datum plan can be instrumented
+   * with JavaScript proxies to detect and report cases where undefined properties
+   * of lenses within the datum plan are accessed.  This is done by including
+   * the *options.planGroup* value within the comma-separated value in the
+   * `DATUM_PLAN_GUARDS` environment variable.
+   *
    * @see DatumPlan_Dsl
    * @see {@tutorial datum-plans} tutorial
    */

--- a/src/datum_plan.js
+++ b/src/datum_plan.js
@@ -1,6 +1,4 @@
 import { isArray, isFunction, isObject } from 'underscore';
-import Lens from './lens.js';
-import { isLensClass as isLens } from '../src-cjs/constants.js';
 
 export function makeExports({fuse, isLens, lens}) {
   const value = '$', others = '((others))';
@@ -15,7 +13,7 @@ export function makeExports({fuse, isLens, lens}) {
     
     buildPlan(rawPlan) {
       if (isArray(rawPlan)) {
-        const result = lens(...this.keys);
+        const result = this.makeLens(...this.keys);
         if (rawPlan.length > 1) {
           throw new Error("Multiple plans for Array items");
         } else if (rawPlan.length) {
@@ -24,7 +22,7 @@ export function makeExports({fuse, isLens, lens}) {
         }
         return result;
       } else if (rawPlan.constructor === Object) {
-        const result = this.keys.length ? lens(...this.keys) : lens();
+        const result = this.keys.length ? this.makeLens(...this.keys) : this.makeLens();
         const theseKeys = this.keys;
         try {
           for (let key of Object.keys(rawPlan)) {
@@ -46,7 +44,7 @@ export function makeExports({fuse, isLens, lens}) {
         }
         return result;
       } else if (rawPlan === value) {
-        return lens(...this.keys);
+        return this.makeLens(...this.keys);
       } else {
         throw new Error("Invalid item in plan");
       }
@@ -98,7 +96,7 @@ export function makeExports({fuse, isLens, lens}) {
          */
         at: function (index, pickLens) {
           // pickLens is given itemPlan to return a lens to fuse with the lens for the item at index
-          const itemLens = lens(...this.keys, index);
+          const itemLens = this.thence(index);
           if (pickLens && pickLens[isLens]) {
             return fuse(itemLens, pickLens);
           } else if (typeof pickLens === 'function') {
@@ -283,7 +281,7 @@ export function makeExports({fuse, isLens, lens}) {
          * lens-like object) rather than a function that returns one.
          */
         at: function (key, pickLens) {
-          const itemLens = lens(...this.keys, key);
+          const itemLens = this.thence(key);
           if (pickLens && pickLens[isLens]) {
             return fuse(itemLens, pickLens);
           } else if (typeof pickLens === 'function') {
@@ -398,6 +396,10 @@ export function makeExports({fuse, isLens, lens}) {
           }));
         },
       };
+    }
+    
+    makeLens(...keys) {
+      return lens(...keys);
     }
   }
 

--- a/src/errors.js
+++ b/src/errors.js
@@ -8,3 +8,32 @@
  */
 class StereoscopyError extends Error {}
 export { StereoscopyError };
+
+/**
+ * @extends Error
+ * @hideconstructor
+ * @classdesc
+ * This error is thrown to indicate a property access on a datum plan lens
+ */
+class UndefinedPropertyError extends Error {
+  constructor(missingProperty, lensKeys, lensProps) {
+    console.log({ lensKeys });
+    const lensDesc = lensKeys.length > 0 ? `Lens with keys ${keyArrayDesc(lensKeys)}` : 'trivial Lens';
+    lensProps = [...lensProps].sort();
+    super(`No such property '${missingProperty}' on ${lensDesc} among properties ${lensProps.map(JSON.stringify).join(', ')}`);
+    this.lensKeys = lensKeys;
+    this.missingProperty = missingProperty;
+  }
+}
+export { UndefinedPropertyError };
+
+function keyArrayDesc(keys) {
+  const content = keys.map(key => {
+    try {
+      return JSON.stringify(key);
+    } catch (e) {
+      return '' + key;
+    }
+  });
+  return `[${content}]`;
+}

--- a/test/datumPlan-tests.js
+++ b/test/datumPlan-tests.js
@@ -792,6 +792,27 @@ function testSequence(loaderName, subjects) {
             assert(caughtException, "Exception expected");
           });
         });
+        
+        it("shows defined properties through a Lens", () => {
+          proxyGuardsEnabled(() => {
+            const plan = datumPlan({name: datumPlan.value}, { planGroup });
+            assert.strictEqual(lens('name').get(plan), plan.name);
+          });
+        });
+        
+        it("shows undefined properties as 'undefined' through a Lens", () => {
+          proxyGuardsEnabled(() => {
+            const plan = datumPlan({name: datumPlan.value}, { planGroup });
+            assert.isUndefined(lens('address').get(plan));
+          });
+        });
+        
+        it("shows undefined properties as Nothing via Lens#get_maybe", () => {
+          proxyGuardsEnabled(() => {
+            const plan = datumPlan({name: datumPlan.value}, { planGroup });
+            assert.notProperty(lens('address').get_maybe(plan), 'just');
+          });
+        });
       });
     });
   });

--- a/test/datumPlan-tests.js
+++ b/test/datumPlan-tests.js
@@ -5,18 +5,18 @@ const _ = require('underscore');
 
 async function loadEsmSubjects() {
   const { default: datumPlan } = await import('#this/datum-plan');
-  const { default: lens } = await import('#this');
-  return { datumPlan, lens };
+  const { default: lens, UndefinedPropertyError } = await import('#this');
+  return { datumPlan, lens, UndefinedPropertyError };
 }
 
 function testSequence(loaderName, subjects) {
   const origIt = it;
   describe(loaderName, () => {
     subjects = Promise.resolve(subjects);
-    let datumPlan, lens;
+    let datumPlan, lens, UndefinedPropertyError;
     
     async function loadSubjects() {
-      ({ datumPlan, lens } = await subjects);
+      ({ datumPlan, lens, UndefinedPropertyError } = await subjects);
     }
     
     let it = (name, body) => {
@@ -706,9 +706,106 @@ function testSequence(loaderName, subjects) {
           assert.deepInclude(result.preferredLanguages, {lang: 'en-us', factor: 1});
         });
       });
+      
+      describe("when Proxy-guarded", () => {
+        const planGroup = '28c85e0f9fdedba40e60e5a909132ef9cc80f882';
+        
+        function proxyGuardsEnabled(body) {
+          const oldVals = Array.from(datumPlan.guardedGroups);
+          datumPlan.guardedGroups.clear();
+          datumPlan.guardedGroups.add(planGroup);
+          try {
+            return body();
+          } finally {
+            datumPlan.guardedGroups.clear();
+            oldVals.forEach((item) => {
+              datumPlan.guardedGroups.add(item);
+            });
+          }
+        }
+        
+        it("activates without error", () => {
+          proxyGuardsEnabled(() => {
+            const plan = datumPlan({name: datumPlan.value}, { planGroup });
+          });
+        });
+        
+        it("lenses like normal for defined properties", () => {
+          proxyGuardsEnabled(() => {
+            const plan = datumPlan({name: datumPlan.value}, { planGroup });
+            const name = "Fred Flintstone";
+            assert.strictEqual(plan.name.get({name}), name);
+          });
+        });
+        
+        it("allows testing for presence with 'in' without error", () => {
+          proxyGuardsEnabled(() => {
+            const plan = datumPlan({name: datumPlan.value}, { planGroup });
+            assert.isNotOk('address' in plan);
+          });
+        });
+        
+        it("throws the expected error type when non-properties are accessed", () => {
+          proxyGuardsEnabled(() => {
+            const plan = datumPlan({name: datumPlan.value}, { planGroup });
+            assert.throws(
+              () => plan.address.get,
+              UndefinedPropertyError
+            );
+          });
+        });
+        
+        it("throws an error indicating where the bad property access occurred", () => {
+          proxyGuardsEnabled(() => {
+            const plan = datumPlan({name: datumPlan.value}, { planGroup });
+            function f16d64e0352ebbc376fa3c5fc216f544ab5ab446() {
+              return plan.address;
+            }
+            assert.doesNotThrow(f16d64e0352ebbc376fa3c5fc216f544ab5ab446);
+            const badAccess = f16d64e0352ebbc376fa3c5fc216f544ab5ab446();
+            try {
+              badAccess.get;
+            } catch (ex) {
+              assert.instanceOf(ex, UndefinedPropertyError);
+              assert.include(ex.stack, 'f16d64e0352ebbc376fa3c5fc216f544ab5ab446', "Stack includes source of error");
+            }
+          });
+        });
+        
+        it("reports the keys leading to the incorrect property access", () => {
+          proxyGuardsEnabled(() => {
+            const plan = datumPlan({
+              name: {
+                first: datumPlan.value,
+                last: datumPlan.value,
+              },
+            }, { planGroup });
+            
+            let caughtException = false;
+            try {
+              plan.name.middle.get;
+            } catch (ex) {
+              caughtException = true;
+              assert.instanceOf(ex, UndefinedPropertyError);
+              assert.include(ex.message, 'name');
+            }
+            assert(caughtException, "Exception expected");
+          });
+        });
+      });
     });
   });
 }
 
-testSequence('CommonJS', { datumPlan, lens });
+testSequence('CommonJS', { datumPlan, lens, UndefinedPropertyError: lens.UndefinedPropertyError });
 testSequence('ESM', loadEsmSubjects());
+
+function withEnv(envvar, value, body) {
+  const oldVal = process.env[envvar];
+  process.env[envvar] = value;
+  try {
+    return body();
+  } finally {
+    process.env[envvar] = oldVal;
+  }
+}


### PR DESCRIPTION
Activate `Proxy`s wrapped around lenses of datum plans tagged with a plan group name (`option.planGroup`) present in `DATUM_PLAN_GUARDS` environment variable.