### PR TITLE
Add `Optic#extractor` and `Optic#extractor_maybe`

### DIFF
--- a/src/optic.js
+++ b/src/optic.js
@@ -321,6 +321,51 @@ class Optic {
       }
     };
   }
+  
+  /**
+   * @summary Construct a Function to extract (and possibly transform) the slot value from a subject
+   * @param {Function} [xform]  The transformation to apply to the slot's value
+   * @returns {Optic~Extractor}  The resulting extractor
+   * @since 2.2.0
+   */
+  extractor(xform) {
+    const inner = this.extractor_maybe(xform);
+    /**
+     * @function Optic~Extractor
+     * @param {*} subject  The input structured data
+     * @returns {*}  The extracted — and possibly transformed — slot value (`undefined` if slot is missing in *subject*)
+     * @since 2.2.0
+     * @see Optic#extractor
+     */
+    return (subject) => inner(subject).just;
+  }
+  
+  /**
+   * @summary Construct a Function to extract (and optionally transform) the slot value from a subject in a Maybe monad
+   * @param {Function} [xform]  The transformation to apply to the slot's value
+   * @returns {Optic~MaybeExtractor}  The resulting extractor
+   * @since 2.2.0
+   *
+   * @description
+   * Like [extractor]{@link Optic#extractor}, but with more clarity in the result
+   * about whether the slot existed or the transform returned `undefined` through
+   * use of the {@link Maybe} monad.
+   */
+  extractor_maybe(xform) {
+    /**
+     * @function Optic~MaybeExtractor
+     * @param {*} subject  The input structured data
+     * @returns {Maybe.<*>}  The extracted — and possibly transformed — slot value in a {@link Maybe} monad
+     * @since 2.2.0
+     * @see Optic#extractor_maybe
+     */
+    return (subject) => {
+      return this.getting(subject, {
+        then(val) {return {just: xform ? xform.call(undefined, val) : val}},
+        else() {return {}}
+      });
+    }
+  }
 }
 Object.assign(Optic.prototype, BinderMixin);
 export default Optic;

--- a/test/lens-tests.js
+++ b/test/lens-tests.js
@@ -816,6 +816,78 @@ function testSequence(loaderName, subjects) {
           assert.equal(L.thence('value').get(data), data[1].value);
         });
       });
+      
+      describe('#extractor()', () => {
+        before(() => {
+          this.L = lens('name');
+        });
+        
+        it("returns a 'getter' by when called without params", () => {
+          const g = this.L.$`get`, x = this.L.extractor();
+          
+          const data = {name: Symbol('test value')};
+          
+          const g_result = g(data), x_result = x(data);
+          assert.strictEqual(g_result, data.name);
+          assert.strictEqual(x_result, g_result);
+        });
+        
+        it("applies the given transform when the slot exists in the subject", () => {
+          const retval = Symbol('retval');
+          const xformFake = sinon.fake.returns(retval);
+          const x = this.L.extractor(xformFake);
+          
+          const data = {name: "Fred Flintstone"};
+          
+          assert.strictEqual(x(data), retval);
+          assert(xformFake.calledOnce);
+          assert.strictEqual(xformFake.firstCall.args[0], this.L.get(data));
+        });
+        
+        it("does not apply the transform when the slot is missing from the subject", () => {
+          const xformFake = sinon.fake.returns('retval');
+          const x = this.L.extractor(xformFake);
+          
+          assert.isUndefined(x({}));
+          assert(xformFake.notCalled);
+        });
+      });
+      
+      describe('#extractor_maybe()', () => {
+        before(() => {
+          this.L = lens('name');
+        });
+        
+        it("returns a 'getter' by when called without params", () => {
+          const g = this.L.$`get`, x = this.L.extractor_maybe();
+          
+          const data = {name: Symbol('test value')};
+          
+          const g_result = g(data), x_result = x(data);
+          assert.strictEqual(g_result, data.name);
+          assert.strictEqual(x_result.just, g_result);
+        });
+        
+        it("applies the given transform when the slot exists in the subject", () => {
+          const retval = Symbol('retval');
+          const xformFake = sinon.fake.returns(retval);
+          const x = this.L.extractor_maybe(xformFake);
+          
+          const data = {name: "Fred Flintstone"};
+          
+          assert.strictEqual(x(data).just, retval);
+          assert(xformFake.calledOnce);
+          assert.strictEqual(xformFake.firstCall.args[0], this.L.get(data));
+        });
+        
+        it("does not apply the transform when the slot is missing from the subject", () => {
+          const xformFake = sinon.fake.returns('retval');
+          const x = this.L.extractor_maybe(xformFake);
+          
+          assert.deepEqual(x({}), {});
+          assert(xformFake.notCalled);
+        });
+      });
     });
 
     describe('CustomStep', () => {

--- a/test/lens-tests.js
+++ b/test/lens-tests.js
@@ -822,7 +822,7 @@ function testSequence(loaderName, subjects) {
           this.L = lens('name');
         });
         
-        it("returns a 'getter' by when called without params", () => {
+        it("returns a 'getter' when called without params", () => {
           const g = this.L.$`get`, x = this.L.extractor();
           
           const data = {name: Symbol('test value')};
@@ -858,7 +858,7 @@ function testSequence(loaderName, subjects) {
           this.L = lens('name');
         });
         
-        it("returns a 'getter' by when called without params", () => {
+        it("returns a Maybe monad 'getter' when called without params", () => {
           const g = this.L.$`get`, x = this.L.extractor_maybe();
           
           const data = {name: Symbol('test value')};
@@ -876,7 +876,7 @@ function testSequence(loaderName, subjects) {
           const data = {name: "Fred Flintstone"};
           
           assert.strictEqual(x(data).just, retval);
-          assert(xformFake.calledOnce);
+          sinon.assert.calledOnce(xformFake);
           assert.strictEqual(xformFake.firstCall.args[0], this.L.get(data));
         });
         
@@ -885,7 +885,7 @@ function testSequence(loaderName, subjects) {
           const x = this.L.extractor_maybe(xformFake);
           
           assert.deepEqual(x({}), {});
-          assert(xformFake.notCalled);
+          sinon.assert.notCalled(xformFake);
         });
       });
     });


### PR DESCRIPTION
These methods build an "extract and transform" function, accepting
subject data, traversing to the optic's slot, then transforming the
value there to produce the result.

Closes #22